### PR TITLE
Reverse parameter order in forEach and filter callbacks

### DIFF
--- a/documentation/api_jszip/filter.md
+++ b/documentation/api_jszip/filter.md
@@ -16,12 +16,12 @@ name      | type     | description
 ----------|----------|------------
 predicate | function | the predicate to use.
 
-The predicate has the following signature : `function (relativePath, file) {...}` :
+The predicate has the following signature : `function (file, relativePath) {...}` :
 
 name         | type      | description
 -------------|-----------|------------
-relativePath | string    | the filename and its path, relative to the current folder.
 file         | ZipObject | the file being tested. See [ZipObject]({{site.baseurl}}/documentation/api_zipobject.html).
+relativePath | string    | the filename and its path, relative to the current folder.
 
 The predicate must return true if the file should be included, false otherwise.
 
@@ -31,7 +31,7 @@ The predicate must return true if the file should be included, false otherwise.
 ```js
 var zip = new JSZip().folder("dir");
 zip.file("readme.txt", "content");
-zip.filter(function (relativePath, file){
+zip.filter(function (file, relativePath){
   // relativePath == "readme.txt"
   // file = {name:"dir/readme.txt",options:{...},async:function}
   return true/false;

--- a/documentation/api_jszip/for_each.md
+++ b/documentation/api_jszip/for_each.md
@@ -16,12 +16,12 @@ name      | type     | description
 ----------|----------|------------
 callback  | function | the callback to use.
 
-The callback has the following signature : `function (relativePath, file) {...}` :
+The callback has the following signature : `function (file, relativePath) {...}` :
 
 name         | type      | description
 -------------|-----------|------------
-relativePath | string    | the filename and its path, relative to the current folder.
 file         | ZipObject | the current file. See [ZipObject]({{site.baseurl}}/documentation/api_zipobject.html).
+relativePath | string    | the filename and its path, relative to the current folder.
 
 
 ## Examples
@@ -34,7 +34,7 @@ zip.file("test/index.html", "...");
 zip.file("test/asserts/file.js", "...");
 zip.file("test/asserts/generate.js", "...");
 
-zip.folder("test").forEach(function (relativePath, file){
+zip.folder("test").forEach(function (file, relativePath){
     console.log("iterating over", relativePath);
 });
 

--- a/documentation/examples/read-local-file-api.inc/read.js
+++ b/documentation/examples/read-local-file-api.inc/read.js
@@ -25,7 +25,7 @@ $("#file").on("change", function(evt) {
                     text:" (loaded in " + (dateAfter - dateBefore) + "ms)"
                 }));
 
-                zip.forEach(function (relativePath, zipEntry) {  // 2) print entries
+                zip.forEach(function (zipEntry, relativePath) {  // 2) print entries
                     $fileContent.append($("<li>", {
                         text : zipEntry.name
                     }));

--- a/index.d.ts
+++ b/index.d.ts
@@ -257,7 +257,7 @@ interface JSZip {
      *
      * @param callback function
      */
-    forEach(callback: (relativePath: string, file: JSZip.JSZipObject) => void): void;
+    forEach(callback: (file: JSZip.JSZipObject, relativePath: string) => void): void;
 
     /**
      * Get all files which match the given filter function
@@ -265,7 +265,7 @@ interface JSZip {
      * @param predicate Filter function
      * @return Array of matched elements
      */
-    filter(predicate: (relativePath: string, file: JSZip.JSZipObject) => boolean): JSZip.JSZipObject[];
+    filter(predicate: (file: JSZip.JSZipObject, relativePath: string) => boolean): JSZip.JSZipObject[];
 
     /**
      * Removes the file or folder from the archive

--- a/lib/generate/index.js
+++ b/lib/generate/index.js
@@ -31,7 +31,7 @@ exports.generateWorker = function (zip, options, comment) {
     var entriesCount = 0;
     try {
 
-        zip.forEach(function (relativePath, file) {
+        zip.forEach(function (file, relativePath) {
             entriesCount++;
             var compression = getCompression(file.options.compression, options.compression);
             var compressionOptions = file.options.compressionOptions || options.compressionOptions || {};

--- a/lib/object.js
+++ b/lib/object.js
@@ -174,8 +174,8 @@ var out = {
     /**
      * Call a callback function for each entry at this folder level.
      * @param {Function} cb the callback function:
-     * function (relativePath, file) {...}
-     * It takes 2 arguments : the relative path and the file.
+     * function (file, relativePath) {...}
+     * It takes 2 arguments : the file and the relative path.
      */
     forEach: function(cb) {
         var filename, relativePath, file;
@@ -185,7 +185,7 @@ var out = {
             file = this.files[filename];
             relativePath = filename.slice(this.root.length, filename.length);
             if (relativePath && filename.slice(0, this.root.length) === this.root) { // the file is in the current root
-                cb(relativePath, file); // TODO reverse the parameters ? need to be clean AND consistent with the filter search fn...
+                cb(file, relativePath);
             }
         }
     },
@@ -193,14 +193,14 @@ var out = {
     /**
      * Filter nested files/folders with the specified function.
      * @param {Function} search the predicate to use :
-     * function (relativePath, file) {...}
-     * It takes 2 arguments : the relative path and the file.
+     * function (file, relativePath) {...}
+     * It takes 2 arguments : the file and the relative path.
      * @return {Array} An array of matching elements.
      */
     filter: function(search) {
         var result = [];
-        this.forEach(function (relativePath, entry) {
-            if (search(relativePath, entry)) { // the file matches the function
+        this.forEach(function (entry, relativePath) {
+            if (search(entry, relativePath)) { // the file matches the function
                 result.push(entry);
             }
 
@@ -221,7 +221,7 @@ var out = {
         if (arguments.length === 1) {
             if (isRegExp(name)) {
                 var regexp = name;
-                return this.filter(function(relativePath, file) {
+                return this.filter(function(file, relativePath) {
                     return !file.dir && regexp.test(relativePath);
                 });
             }
@@ -252,7 +252,7 @@ var out = {
         }
 
         if (isRegExp(arg)) {
-            return this.filter(function(relativePath, file) {
+            return this.filter(function(file, relativePath) {
                 return file.dir && arg.test(relativePath);
             });
         }
@@ -288,7 +288,7 @@ var out = {
             delete this.files[name];
         } else {
             // maybe a folder, delete recursively
-            var kids = this.filter(function(relativePath, file) {
+            var kids = this.filter(function(file) {
                 return file.name.slice(0, name.length) === name;
             });
             for (var i = 0; i < kids.length; i++) {

--- a/test/asserts/filter.js
+++ b/test/asserts/filter.js
@@ -7,7 +7,7 @@ QUnit.test("Filtering a zip", function(assert) {
     zip.file("1.txt", "1\n");
     zip.file("2.txt", "2\n");
     zip.file("3.log", "3\n");
-    var result = zip.filter(function(relativeFilename) {
+    var result = zip.filter(function(file, relativeFilename) {
         return relativeFilename.indexOf(".txt") !== -1;
     });
     assert.equal(result.length, 2, "filter has filtered");
@@ -25,7 +25,7 @@ QUnit.test("Filtering a zip from a relative path", function(assert) {
     zip.file("3.log", "3\n");
 
     var count = 0;
-    var result = zip.folder("foo").filter(function(relativeFilename) {
+    var result = zip.folder("foo").filter(function(file, relativeFilename) {
         count++;
         return relativeFilename.indexOf("3") !== -1;
     });
@@ -43,7 +43,7 @@ QUnit.test("Filtering a zip : the full path is still accessible", function(asser
     zip.file("2.txt", "2\n");
     zip.file("3.log", "3\n");
 
-    var result = zip.folder("foo").filter(function(relativeFilename, file) {
+    var result = zip.folder("foo").filter(function(file, relativeFilename) {
         return file.name.indexOf("3") !== -1;
     });
     assert.equal(result.length, 1, "the filter only match files/folders in the current folder");

--- a/test/asserts/foreach.js
+++ b/test/asserts/foreach.js
@@ -9,7 +9,7 @@ QUnit.test("forEach works on /", function (assert) {
 
     assert.equal(zip.root, "");
 
-    zip.forEach(function (path, elt) {
+    zip.forEach(function (elt, path) {
         assert.equal(path, elt.name, "the full path is given on / for " + elt.name);
         count++;
         calls.push(path);
@@ -30,7 +30,7 @@ QUnit.test("forEach works on a sub folder", function (assert) {
     assert.ok(zip.file("subfolder/Hello.txt"));
     assert.equal(sub.root, "subfolder/");
 
-    sub.forEach(function (path, elt) {
+    sub.forEach(function (elt, path) {
         assert.equal(path, elt.name.substr("subfolder/".length), "the full path is given on subfolder/ for " + path);
         count++;
         calls.push(path);


### PR DESCRIPTION
Reversed the parameter order for `forEach` and `filter` callbacks to `(file, relativePath)` for consistency with JavaScript conventions. This included updating the core logic, internal calls, tests, documentation, and TypeScript definitions.

---
*PR created automatically by Jules for task [13977155798580443786](https://jules.google.com/task/13977155798580443786) started by @brianpt1984*